### PR TITLE
Fix 500 error when using stream mode

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -3,6 +3,8 @@
 const url = require('url');
 const qs = require('qs');
 const Joi = require('joi');
+const stream = require('stream');
+
 const DECODE_CONTENT_TYPE_REGEXP = /(x-www-form-urlencoded)|(multipart\/form-data)/;
 
 const OPTIONS_SCHEMA = Joi.object().keys({
@@ -46,6 +48,7 @@ function onPostAuthFactory(qsOptions) {
 
     if (decode &&
         typeof request.payload === 'object' &&
+        !(request.payload instanceof stream.Stream) &&
         !Buffer.isBuffer(request.payload)) {
 
         request.payload = qs.parse(request.payload, qsOptions);

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   },
   "homepage": "https://github.com/daf-spr/hapi-qs#readme",
   "dependencies": {
+    "hapi": "^16.1.0",
     "joi": "^7.0.1",
     "qs": "^6.0.1"
   },

--- a/tests/support/basic_server.js
+++ b/tests/support/basic_server.js
@@ -15,12 +15,15 @@ exports.start = function(port, pluginOptions, serverOptions, callback) {
 
   server.connection({ port: port });
 
-  const preparePayloadRoute = function (method) {
+  const preparePayloadRoute = function (method, options) {
     server.route({
       method: method,
-      path: '/test',
-      handler: function (request, reply) {
-        return reply(request.payload);
+      path: options.path,
+      config: {
+        payload: Object.assign({}, options.config && options.config.payload),
+        handler: function (request, reply) {
+          return reply(request.payload);
+        }
       }
     });
   };
@@ -34,10 +37,25 @@ exports.start = function(port, pluginOptions, serverOptions, callback) {
       }
     });
 
-    preparePayloadRoute('POST');
-    preparePayloadRoute('PUT');
-    preparePayloadRoute('PATCH');
-    preparePayloadRoute('DELETE');
+    preparePayloadRoute('POST', { path: '/test' });
+    preparePayloadRoute('PUT', { path: '/test' });
+    preparePayloadRoute('PATCH', { path: '/test' });
+    preparePayloadRoute('DELETE', { path: '/test' });
+
+    const streamPayload = {
+      path: '/test-stream',
+      config: {
+        payload: {
+          output: 'stream',
+          parse: false
+        }
+      }
+    };
+
+    preparePayloadRoute('POST', streamPayload);
+    preparePayloadRoute('PUT', streamPayload);
+    preparePayloadRoute('PATCH', streamPayload);
+    preparePayloadRoute('DELETE', streamPayload);
 
     server.start(() => callback(null, server));
   };


### PR DESCRIPTION
When using stream mode + multipart the stream was being
past to the parse which caused the 500 error issue. This
is a fix for this bahavior, the payload won't be passed
to the parsed anymore if payload is an stream.