### PR TITLE
Resolve CVE-2018-3728/NSP-566

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "homepage": "https://github.com/daf-spr/hapi-qs#readme",
   "dependencies": {
-    "joi": "^7.0.1",
+    "joi": "^13.1.2",
     "qs": "^6.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Resolves a known vulnerability, [NSP-566](https://nodesecurity.io/advisories/566) ([CVE-2018-3728](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-3728)), introduced to this module by a vulnerable version of hoek through the joi dependency.

Resolves #19 